### PR TITLE
security: remove polyfill.io script tag + FIX CI

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,7 +11,14 @@ module.exports = {
     name: "@storybook/react-vite",
     options: {},
   },
-
+  core: {
+    builder: {
+      name: "@storybook/builder-vite",
+      options: {
+        viteConfigPath: "./vite.config.storybook.mts",
+      },
+    },
+  },
   docs: {
     autodocs: true,
   },

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,5 +3,4 @@
   href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400&family=IBM+Plex+Serif:ital,wght@0,500;0,700;1,500;1,700&family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap"
   rel="stylesheet"
 />
-<script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.replaceAll%2CArray.prototype.map%2CArray.prototype.reduce"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDy8e6_8uv8JnNZFRXng6HfbhnhvobWyac&libraries=places"></script>


### PR DESCRIPTION
Removes the `polyfill.io` CDN script tag from `.storybook/preview-head.html`.

The domain was compromised in 2024 and used to inject malicious JavaScript on mobile. All loaded features (`replaceAll`, `map`, `reduce`) are natively supported by modern browsers — no alternative needed.

Ref: https://www.agid.gov.it/it/notizie/polyfillio-il-cert-agid-consiglia-alle-pa-che-lo-utilizzano-sui-loro-siti-di-rimuoverlo

---

Fixes CI: configure Storybook to use `vite.config.storybook.mts` instead of the default `vite.config.mts`.

The main Vite config includes `vite-plugin-dts` with `rollupTypes: true`, which triggers API Extractor and requires `dist/index.d.ts` to exist. During Storybook build in CI that file is not present, causing the build to fail. The storybook-specific config skips this step entirely.

Same fix already applied in `unguess-design-system`: AppQuality/unguess-design-system@a320739